### PR TITLE
chore: bump version to 0.0.3 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harbor-mcp",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "build/index.js",
   "type": "module",
   "bin": {


### PR DESCRIPTION
This PR bumps the project version to 0.0.3 in package.json.

- Updates the version field to 0.0.3 to reflect the latest changes and improvements.
- Keeps the project versioning in sync with recent updates and releases.

No other code or dependency changes are included in this PR.

---

If you have any questions or need further details, please let me know!