### PR TITLE
docs: add OWNERS.md to document project ownership

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,3 @@
+# Project Owners
+
+- bupd 


### PR DESCRIPTION
### Summary
This PR introduces an `OWNERS.md` file to the repository, listing the current project owner(s).

### Details
- Adds `OWNERS.md` to clearly indicate project stewardship and provide a point of contact for contributors and maintainers.

### Motivation
Having an `OWNERS.md` file helps clarify who is responsible for the project, making it easier for the community to know whom to contact for questions, reviews, or contributions.

---
If additional owners or details are needed, feel free to update this file in future PRs.